### PR TITLE
[fix] Don't leak globals when used as a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 
 var Back = module.exports = function reconnect(callback, opts) {
+  if (!(this instanceof Back)) {
+    return new Back(callback, opts);
+  }
 
   opts = opts || {};
 


### PR DESCRIPTION
When used as in `README` (called as `require('back')()`), the module was
leaking globals because it used `this` when not being in the right
context.

This caused problems when using more than one `back` instances created
like that.
